### PR TITLE
gpu-version for flatten-layer

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -329,6 +329,8 @@ class FlattenLayer : public Layer<Dtype> {
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+                           const vector<Blob<Dtype>*>& top);
   /**
    * @brief Computes the error gradient w.r.t. the concatenate inputs.
    *
@@ -339,6 +341,9 @@ class FlattenLayer : public Layer<Dtype> {
    *        gradient is (virtually) copied
    */
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 };
 


### PR DESCRIPTION
This should fix compiling errors due missing gpu-method-definition (Flatten-Layer).
